### PR TITLE
Creator Hub link, fixes, and cleanup

### DIFF
--- a/app/pages/creator-hub.tsx
+++ b/app/pages/creator-hub.tsx
@@ -25,7 +25,6 @@ const connection = new anchor.web3.Connection(
 const CreatorHub = () => {
   const { user, fetchUserDetails } = useUser();
   const [benefits, setBenefits] = useState<Array<Benefit>>([]);
-  console.log('benefits', benefits);
 
   const usernameRef = useRef<HTMLInputElement>(null);
   const emailRef = useRef<HTMLInputElement>(null);
@@ -56,8 +55,6 @@ const CreatorHub = () => {
         program.programId
       );
 
-      console.log(user.creatorAccount);
-
       const benefitArray = [];
       for (let i = 1; i <= user.creatorAccount.numBenefits; i++) {
         const benefitNumber = `${i}`;
@@ -87,9 +84,6 @@ const CreatorHub = () => {
 
   const handleNewBenefit = async () => {
     if (connectedWallet && program) {
-      // Get new benefit number
-      // It's not this simple since we can delete a benefit in the middle...
-      console.log(benefits);
       const newBenefitNumber = `${benefits.length + 1}`;
 
       const creatorSeeds = [
@@ -126,6 +120,7 @@ const CreatorHub = () => {
         await program.rpc.createBenefit(
           newBenefit.name,
           newBenefit.description,
+          '', // access_link
           newBenefitNumber,
           {
             accounts: {
@@ -241,7 +236,7 @@ const CreatorHub = () => {
   return (
     <div className="flex h-full w-full flex-col items-center">
       {user.creatorAccount && (
-        <div className="prose mb-8 w-3/5 text-center">
+        <div className="prose mt-8 mb-8 w-3/5 text-center">
           <div>
             {!isEditingName ? (
               <h2 className="inline">{user.creatorAccount.username}</h2>
@@ -276,12 +271,15 @@ const CreatorHub = () => {
               </p>
             </div>
           </div>
-          <div className="flex justify-around">
-            <p>Revenue: $80000</p>
-            {user.subscriptions && (
-              <p>Subscribers: {user.subscriptions.length}</p>
-            )}
-          </div>
+          {user.subscriptions && (
+            <div className="flex justify-around">
+              <p>
+                Monthly Revenue: {Object.keys(user.subscriptions).length * 0.1}{' '}
+                SOL
+              </p>
+              <p>Subscribers: {Object.keys(user.subscriptions).length}</p>
+            </div>
+          )}
           <div>
             {!isEditingDescription ? (
               <p className="inline">{user.creatorAccount.description}</p>
@@ -320,7 +318,10 @@ const CreatorHub = () => {
           ))}
         </div>
       )}
-      <button className="btn btn-outline btn-sm mt-2 h-12 w-32">
+      <button
+        className="btn btn-outline btn-sm mt-2 h-12 w-32"
+        onClick={handleNewBenefit}
+      >
         Add Benefit
       </button>
     </div>

--- a/app/pages/creator-hub.tsx
+++ b/app/pages/creator-hub.tsx
@@ -7,6 +7,7 @@ import IDL from '../../target/idl/nft_club.json';
 import { Benefit } from '../types/Benefit';
 import { useUser } from '../hooks/useUser';
 import BenefitCard from './components/BenefitCard';
+import { useRouter } from 'next/router';
 
 const PROGRAM_ID = new anchor.web3.PublicKey(
   'CZeXHMniVHpEjkXTBzbpTJWR4qzgyZfRtjvviSxoUrWZ'
@@ -33,6 +34,8 @@ const CreatorHub = () => {
   const [isEditingName, setIsEditingName] = useState(false);
   const [isEditingEmail, setIsEditingEmail] = useState(false);
   const [isEditingDescription, setIsEditingDescription] = useState(false);
+
+  const router = useRouter();
 
   const connectedWallet = useAnchorWallet();
   const program = useMemo(() => {
@@ -236,73 +239,89 @@ const CreatorHub = () => {
   return (
     <div className="flex h-full w-full flex-col items-center">
       {user.creatorAccount && (
-        <div className="prose mt-8 mb-8 w-3/5 text-center">
-          <div>
-            {!isEditingName ? (
-              <h2 className="inline">{user.creatorAccount.username}</h2>
-            ) : (
-              <input
-                className="input-value ml-2 rounded-xl bg-slate-200 p-1 text-primary"
-                defaultValue={user.creatorAccount.username}
-                ref={usernameRef}
-              ></input>
-            )}
-            <p
-              className="inline cursor-pointer pl-2 text-gray-400"
-              onClick={() => toggleEditCreator('username')}
-            >
-              {!isEditingName ? 'Edit' : 'Cancel'}
-            </p>
+        <div className="mt-4 mb-8 flex w-full flex-col-reverse items-center">
+          <div className="prose w-full justify-self-center text-center">
             <div>
-              {!isEditingEmail ? (
-                <p className="inline">{user.creatorAccount.email}</p>
+              {!isEditingName ? (
+                <h2 className="inline">{user.creatorAccount.username}</h2>
               ) : (
                 <input
                   className="input-value ml-2 rounded-xl bg-slate-200 p-1 text-primary"
-                  defaultValue={user.creatorAccount.email}
-                  ref={emailRef}
+                  defaultValue={user.creatorAccount.username}
+                  ref={usernameRef}
                 ></input>
               )}
               <p
                 className="inline cursor-pointer pl-2 text-gray-400"
-                onClick={() => toggleEditCreator('email')}
+                onClick={() => toggleEditCreator('username')}
               >
-                {!isEditingEmail ? 'Edit' : 'Cancel'}
+                {!isEditingName ? 'Edit' : 'Cancel'}
+              </p>
+              <div>
+                {!isEditingEmail ? (
+                  <p className="inline">{user.creatorAccount.email}</p>
+                ) : (
+                  <input
+                    className="input-value ml-2 rounded-xl bg-slate-200 p-1 text-primary"
+                    defaultValue={user.creatorAccount.email}
+                    ref={emailRef}
+                  ></input>
+                )}
+                <p
+                  className="inline cursor-pointer pl-2 text-gray-400"
+                  onClick={() => toggleEditCreator('email')}
+                >
+                  {!isEditingEmail ? 'Edit' : 'Cancel'}
+                </p>
+              </div>
+            </div>
+            {user.subscriptions && (
+              <div className="flex justify-around">
+                <p>
+                  Monthly Revenue:{' '}
+                  {Object.keys(user.subscriptions).length * 0.1} SOL
+                </p>
+                <p>Subscribers: {Object.keys(user.subscriptions).length}</p>
+              </div>
+            )}
+            <div>
+              {!isEditingDescription ? (
+                <p className="inline">{user.creatorAccount.description}</p>
+              ) : (
+                <input
+                  className="input-value ml-2 rounded-xl bg-slate-200 p-1 text-primary"
+                  defaultValue={user.creatorAccount.description}
+                  ref={descriptionRef}
+                ></input>
+              )}
+              <p
+                className="inline cursor-pointer pl-2 text-gray-400"
+                onClick={() => toggleEditCreator('description')}
+              >
+                {!isEditingDescription ? 'Edit' : 'Cancel'}
               </p>
             </div>
+            <button
+              className="btn btn-outline btn-sm mt-2 h-12 w-32"
+              onClick={updateAccount}
+            >
+              Update Account
+            </button>
           </div>
-          {user.subscriptions && (
-            <div className="flex justify-around">
-              <p>
-                Monthly Revenue: {Object.keys(user.subscriptions).length * 0.1}{' '}
-                SOL
+          {connectedWallet && connectedWallet.publicKey && (
+            <div className="mr-8 self-end">
+              <p
+                className="cursor-pointer"
+                onClick={() =>
+                  router.push(
+                    `/creator-landing-page/${connectedWallet.publicKey.toBase58()}`
+                  )
+                }
+              >
+                View Landing Page {`\u2794`}
               </p>
-              <p>Subscribers: {Object.keys(user.subscriptions).length}</p>
             </div>
           )}
-          <div>
-            {!isEditingDescription ? (
-              <p className="inline">{user.creatorAccount.description}</p>
-            ) : (
-              <input
-                className="input-value ml-2 rounded-xl bg-slate-200 p-1 text-primary"
-                defaultValue={user.creatorAccount.description}
-                ref={descriptionRef}
-              ></input>
-            )}
-            <p
-              className="inline cursor-pointer pl-2 text-gray-400"
-              onClick={() => toggleEditCreator('description')}
-            >
-              {!isEditingDescription ? 'Edit' : 'Cancel'}
-            </p>
-          </div>
-          <button
-            className="btn btn-outline btn-sm mt-2 h-12 w-32"
-            onClick={updateAccount}
-          >
-            Update Account
-          </button>
         </div>
       )}
       {benefits && benefits.length > 0 && (


### PR DESCRIPTION
Adds a link in the upper right corner to view the creator landing page, which routes according to the connected wallet's public key in Base 58 format.

Additionally, fixes Benefit account creation from the Creator Hub (access links were not added here, so Benefit creation was failing), computes monthly revenue, correctly displays number of subscribers, and adds minor adjustments to css.